### PR TITLE
Fix ForEach warning

### DIFF
--- a/Emitron/Emitron/UI/Generic/PagingIndicatorView.swift
+++ b/Emitron/Emitron/UI/Generic/PagingIndicatorView.swift
@@ -34,7 +34,7 @@ struct PagingIndicatorView: View {
   
   var body: some View {
     HStack(spacing: 9) {
-      ForEach(0..<pageCount - 1) { index in
+      ForEach(0..<pageCount - 1, id: \.self) { index in
         Circle()
           .fill(index == currentIndex ? Color.accent : .borderColor)
           .frame(width: 9, height: 9)


### PR DESCRIPTION
This fix's the warning Non-constant range: argument must be an integer literal